### PR TITLE
いい感じに修正しました。

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,17 +1,34 @@
 'use client';
 
+import { hydrateDiaryState } from '@/features/diary/diarySlice';
 import { loadPersistedState, setupPersistence } from '@/lib/persist';
 import { type AppStore, makeStore } from '@/lib/store';
-import { type ReactNode, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { Provider } from 'react-redux';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const storeRef = useRef<AppStore | null>(null);
   if (!storeRef.current) {
-    const preloadedState = loadPersistedState();
-    storeRef.current = makeStore(preloadedState);
-    setupPersistence(storeRef.current);
+    storeRef.current = makeStore();
   }
+
+  useEffect(() => {
+    const store = storeRef.current;
+    if (!store) return;
+
+    const persisted = loadPersistedState();
+    if (persisted?.diary) {
+      store.dispatch(
+        hydrateDiaryState({
+          diaries: persisted.diary.diaries ?? [],
+          selectedId: persisted.diary.selectedId ?? null,
+        })
+      );
+    }
+
+    const cleanup = setupPersistence(store);
+    return cleanup;
+  }, []);
 
   return <Provider store={storeRef.current}>{children}</Provider>;
 }

--- a/components/DiaryCard.tsx
+++ b/components/DiaryCard.tsx
@@ -14,15 +14,12 @@ import {
 import type { Diary } from '@/features/diary/diarySlice';
 
 function formatDate(iso: string) {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleString('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const parts = iso.split('T');
+  if (parts.length < 2) return iso;
+  const ymd = parts[0].replaceAll('-', '/');
+  const hhmm = parts[1].slice(0, 5);
+  if (!ymd || hhmm.length < 4) return iso;
+  return `${ymd} ${hhmm}`;
 }
 
 export function DiaryCard({

--- a/features/diary/diarySlice.ts
+++ b/features/diary/diarySlice.ts
@@ -71,6 +71,13 @@ export const diarySlice = createSlice({
   name: 'diary',
   initialState,
   reducers: {
+    hydrateDiaryState(
+      state,
+      action: PayloadAction<{ diaries: Diary[]; selectedId: string | null }>
+    ) {
+      state.diaries = action.payload.diaries;
+      state.selectedId = action.payload.selectedId;
+    },
     addDiary: {
       reducer(state, action: PayloadAction<Diary>) {
         state.diaries.unshift(action.payload);
@@ -112,5 +119,6 @@ export const diarySlice = createSlice({
   },
 });
 
-export const { addDiary, updateDiary, deleteDiary } = diarySlice.actions;
+export const { hydrateDiaryState, addDiary, updateDiary, deleteDiary } =
+  diarySlice.actions;
 export default diarySlice.reducer;

--- a/lib/persist.ts
+++ b/lib/persist.ts
@@ -113,11 +113,19 @@ export function setupPersistence(store: {
 }) {
   let timeout: ReturnType<typeof setTimeout> | null = null;
 
-  store.subscribe(() => {
+  const unsubscribe = store.subscribe(() => {
     if (timeout) return;
     timeout = setTimeout(() => {
       timeout = null;
       savePersistedState(store.getState());
     }, 250);
   });
+
+  return () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    unsubscribe();
+  };
 }


### PR DESCRIPTION
Next.jsで以下のエラーが出ていたので、修正しました。
# React Hydration Error 修正内容

## エラー概要

Next.js（App Router）において **Hydration Error** が発生しています。

主な症状は以下です：

- サーバーで生成された HTML と
- クライアントで初回レンダリングされた HTML

が一致していないため、React が再構築（hydrate）できずエラーになっています。

今回の差分では、**DiaryCard 内の表示内容が Server / Client で異なっている**ことが原因です。

```diff
+ src="https://images.unsplash.com/photo-1504384308090-..."
- src="https://images.unsplash.com/photo-1496307042754-..."

+ alt="test title"
- alt="はじめての日記"

+ test title
- はじめての日記
根本原因（今回のケース）
❌ 問題点
以下のいずれか、もしくは複合です。

初期表示時に Math.random() や Date.now() を直接使っている

サーバーとクライアントで初期データが一致していない

Diary データを Client Component 側で生成している

useEffect 前後で表示内容が変わっている

今回のログから判断すると、最も可能性が高いのは：

日記データ（title / image URL）を Client Component 側でランダム生成している

修正方針（正解）
原則
初回レンダリングで使うデータは、Server / Client で完全に一致させる

修正方法①（推奨）
ランダム値・日時生成を reducer or action 内に移動する
❌ NG（Component 内で生成）

ts
コードをコピーする
// ❌ ダメ：レンダリング毎に変わる
const diary = {
  id: crypto.randomUUID(),
  title: Math.random() > 0.5 ? 'test title' : 'はじめての日記',
}
✅ OK（dispatch 時に一度だけ生成）

ts
コードをコピーする
// diarySlice.ts
addDiary: (state, action) => {
  state.diaries.push({
    id: crypto.randomUUID(),
    title: action.payload.title,
    content: action.payload.content,
    imageUrl: action.payload.imageUrl,
    createdAt: new Date().toISOString(),
    updatedAt: new Date().toISOString(),
  })
}
➡ レンダリング中に値が変わらなくなる

修正方法②
初期ダミーデータを固定値にする
ts
コードをコピーする
const initialState = {
  diaries: [
    {
      id: 'dummy-1',
      title: 'はじめての日記',
      content: 'これはサンプルの日記です',
      imageUrl: 'https://images.unsplash.com/photo-1496307042754-b4aa456c4a2d',
      createdAt: '2026-01-01T00:00:00.000Z',
      updatedAt: '2026-01-01T00:00:00.000Z',
    },
  ],
}
➡ Server / Client で 完全一致

修正方法③（最終手段・非推奨）
Client Only Rendering にする
ts
コードをコピーする
'use client'
import dynamic from 'next/dynamic'

export default dynamic(() => import('./DiaryList'), {
  ssr: false,
})
⚠️ SEO・初期表示性能が落ちるため非推奨

今回のケースでの結論（ベストプラクティス）
✅ DiaryCard / DiaryList は「純粋な表示コンポーネント」にする
✅ データ生成（ランダム・日時）は reducer / action で一度だけ行う
✅ 初期表示に使う値は固定 or サーバー由来にする